### PR TITLE
Send output to stderr so as not to interfere with pipelines.

### DIFF
--- a/include/progressbar.hpp
+++ b/include/progressbar.hpp
@@ -127,11 +127,11 @@ inline void progressbar::update() {
 
     if (!update_is_called) {
         if (do_show_bar == true) {
-            std::cout << opening_bracket_char;
-            for (int _ = 0; _ < 50; _++) std::cout << todo_char;
-            std::cout << closing_bracket_char << " 0%";
+            std::cerr << opening_bracket_char;
+            for (int _ = 0; _ < 50; _++) std::cerr << todo_char;
+            std::cerr << closing_bracket_char << " 0%";
         }
-        else std::cout << "0%";
+        else std::cerr << "0%";
     }
     update_is_called = true;
 
@@ -144,39 +144,39 @@ inline void progressbar::update() {
     // update percentage each unit
     if (perc == last_perc + 1) {
         // erase the correct  number of characters
-        if      (perc <= 10)                std::cout << "\b\b"   << perc << '%';
-        else if (perc  > 10 and perc < 100) std::cout << "\b\b\b" << perc << '%';
-        else if (perc == 100)               std::cout << "\b\b\b" << perc << '%';
+        if      (perc <= 10)                std::cerr << "\b\b"   << perc << '%';
+        else if (perc  > 10 and perc < 100) std::cerr << "\b\b\b" << perc << '%';
+        else if (perc == 100)               std::cerr << "\b\b\b" << perc << '%';
     }
     if (do_show_bar == true) {
         // update bar every ten units
         if (perc % 2 == 0) {
             // erase closing bracket
-            std::cout << std::string(closing_bracket_char.size(), '\b');
+            std::cerr << std::string(closing_bracket_char.size(), '\b');
             // erase trailing percentage characters
-            if      (perc  < 10)               std::cout << "\b\b\b";
-            else if (perc >= 10 && perc < 100) std::cout << "\b\b\b\b";
-            else if (perc == 100)              std::cout << "\b\b\b\b\b";
+            if      (perc  < 10)               std::cerr << "\b\b\b";
+            else if (perc >= 10 && perc < 100) std::cerr << "\b\b\b\b";
+            else if (perc == 100)              std::cerr << "\b\b\b\b\b";
 
             // erase 'todo_char'
             for (int j = 0; j < 50-(perc-1)/2; ++j) {
-                std::cout << std::string(todo_char.size(), '\b');
+                std::cerr << std::string(todo_char.size(), '\b');
             }
 
             // add one additional 'done_char'
-            if (perc == 0) std::cout << todo_char;
-            else           std::cout << done_char;
+            if (perc == 0) std::cerr << todo_char;
+            else           std::cerr << done_char;
 
             // refill with 'todo_char'
-            for (int j = 0; j < 50-(perc-1)/2-1; ++j) std::cout << todo_char;
+            for (int j = 0; j < 50-(perc-1)/2-1; ++j) std::cerr << todo_char;
 
             // readd trailing percentage characters
-            std::cout << closing_bracket_char << ' ' << perc << '%';
+            std::cerr << closing_bracket_char << ' ' << perc << '%';
         }
     }
     last_perc = perc;
     ++progress;
-    std::cout << std::flush;
+    std::cerr << std::flush;
 
     return;
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -28,7 +28,7 @@ int main() {
         std::this_thread::sleep_for( std::chrono::microseconds(300) );
     }
 
-    std::cout << std::endl;
+    std::cerr << std::endl;
 
     N = 5000;
     bar.set_niter(N);
@@ -45,7 +45,7 @@ int main() {
         std::this_thread::sleep_for( std::chrono::microseconds(300) );
     }
 
-    std::cout << std::endl;
+    std::cerr << std::endl;
     bar.reset();
     bar.show_bar(false);
     for ( int i = 0; i < N; i++ ) {


### PR DESCRIPTION
I simply replaced all occurrences of cout with cerr.

The usual behavior of terminal progress bars is to send output to either stderr or the tty, rather than stdout.